### PR TITLE
feat: Content Security Policy: strict-dynamic + (cached) nonce

### DIFF
--- a/404.html
+++ b/404.html
@@ -2,8 +2,13 @@
 <html>
 
 <head>
+  <meta
+    http-equiv="Content-Security-Policy"
+    content="script-src 'nonce-aem' 'strict-dynamic' 'unsafe-inline' http: https:; base-uri 'self'; object-src 'none';"
+    move-to-http-header="true"
+  >
   <title>Page not found</title>
-  <script type="importmap">
+  <script nonce="aem" type="importmap">
     {
         "imports": {
             "@dropins/tools/": "/scripts/__dropins__/tools/",
@@ -12,13 +17,13 @@
         }
     }
   </script>
-  <script type="text/javascript">
+  <script nonce="aem" type="text/javascript">
     window.isErrorPage = true;
     window.errorCode = '404';
   </script>
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta property="og:title" content="Page not found">
-  <script type="module">
+  <script nonce="aem" type="module">
     await fetch('/metadata.json')
       .then((res) => res.json())
       .then(({ data = [] }) => {
@@ -54,8 +59,8 @@
         console.error(err);
       });
   </script>
-  <script src="/scripts/scripts.js" type="module"></script>
-  <script type="module">
+  <script nonce="aem" src="/scripts/scripts.js" type="module"></script>
+  <script nonce="aem" type="module">
     window.addEventListener('load', () => {
       if (document.referrer) {
         const { origin, pathname } = new URL(document.referrer);
@@ -71,7 +76,7 @@
       }
     });
   </script>
-  <script type="module">
+  <script nonce="aem" type="module">
     import { sampleRUM } from '/scripts/aem.js';
     sampleRUM('404', { source: document.referrer });
   </script>

--- a/404.html
+++ b/404.html
@@ -13,7 +13,8 @@
         "imports": {
             "@dropins/tools/": "/scripts/__dropins__/tools/",
             "@dropins/storefront-cart/": "/scripts/__dropins__/storefront-cart/",
-            "@dropins/storefront-auth/": "/scripts/__dropins__/storefront-auth/"
+            "@dropins/storefront-auth/": "/scripts/__dropins__/storefront-auth/",
+            "@dropins/storefront-personalization/": "/scripts/__dropins__/storefront-personalization/"
         }
     }
   </script>

--- a/404.html
+++ b/404.html
@@ -11,10 +11,10 @@
   <script nonce="aem" type="importmap">
     {
         "imports": {
-            "@dropins/tools/": "/scripts/__dropins__/tools/",
-            "@dropins/storefront-cart/": "/scripts/__dropins__/storefront-cart/",
-            "@dropins/storefront-auth/": "/scripts/__dropins__/storefront-auth/",
-            "@dropins/storefront-personalization/": "/scripts/__dropins__/storefront-personalization/"
+          "@dropins/tools/": "/scripts/__dropins__/tools/",
+          "@dropins/storefront-cart/": "/scripts/__dropins__/storefront-cart/",
+          "@dropins/storefront-auth/": "/scripts/__dropins__/storefront-auth/",
+          "@dropins/storefront-personalization/": "/scripts/__dropins__/storefront-personalization/"
         }
     }
   </script>

--- a/head.html
+++ b/head.html
@@ -1,5 +1,10 @@
+<meta
+  http-equiv="Content-Security-Policy"
+  content="script-src 'nonce-aem' 'strict-dynamic' 'unsafe-inline' http: https:; base-uri 'self'; object-src 'none';"
+  move-to-http-header="true"
+>
 <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1" />
-<script type="speculationrules">
+<script nonce="aem" type="speculationrules">
     {
         "prerender": [{
             "where": {
@@ -9,7 +14,7 @@
         }]
     }
 </script>
-<script type="importmap">
+<script nonce="aem" type="importmap">
     {
         "imports": {
             "@dropins/storefront-account/": "/scripts/__dropins__/storefront-account/",
@@ -30,15 +35,15 @@
 
 <link rel="stylesheet" href="/styles/styles.css" />
 
-<script type="module">
+<script nonce="aem" type="module">
     if (!(HTMLScriptElement.supports?.('importmap'))) {
         import('/scripts/__dropins__/tools/shims/importmap.js');
     }
 </script>
 
-<script src="/scripts/aem.js" type="module"></script>
-<script src="/scripts/scripts.js" type="module"></script>
-<script src="/scripts/commerce.js" type="module"></script>
+<script nonce="aem" src="/scripts/aem.js" type="module"></script>
+<script nonce="aem" src="/scripts/scripts.js" type="module"></script>
+<script nonce="aem" src="/scripts/commerce.js" type="module"></script>
 
 <link rel="modulepreload" href="/scripts/__dropins__/tools/lib/aem/configs.js" />
 <link rel="modulepreload" href="/scripts/initializers/index.js" />


### PR DESCRIPTION
Porting the out of the box configuration configuration of https://www.aem.live/docs/csp-strict-dynamic-cached-nonce to xWalk.

PRs in the aem-boilerplate  and aem-commerce-boilerplate for reference:
* https://github.com/adobe/aem-boilerplate/pull/493
* https://github.com/hlxsites/aem-boilerplate-commerce/pull/649

Same as for https://github.com/adobe-rnd/aem-boilerplate-xwalk/pull/75 would be very grateful for a more in depth test from the xWalk team with more knowledge. 🙏


Test URLs:
- Before: https://main--aem-boilerplate-xcom--adobe-rnd.aem.live/
- After: https://csp--aem-boilerplate-xcom--adobe-rnd.aem.live/
